### PR TITLE
Widget migration/child pages to widgets

### DIFF
--- a/Migration.Tool.CLI/appsettings.json
+++ b/Migration.Tool.CLI/appsettings.json
@@ -34,7 +34,7 @@
     "LegacyFlatAssetTree": false,
     "AssetRootFolders": {},
     "UseDeprecatedFolderPageType": false,
-    "ConvertClassesToContentHub": "",
+    "ConvertClassesToContentHub": "DancingGoatCore.AboutUsSection",
     "CreateReusableFieldSchemaForClasses": "",
     "TargetWorkspaceName": "",
     "OptInFeatures": {

--- a/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
+++ b/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
@@ -12,7 +12,7 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
             // 1. Widget host page tree node: Ensure the template exists and is available in XbyK target project
             if (source.SourceNode.NodeAliasPath == "/About-Us")
             {
-                options.OverridePageTemplate("PageWithWidgetsDefaultTemplate");
+                options.OverridePageTemplate("DancingGoat.LandingPageSingleColumn");
             }
             // 2. Nodes to be converted to widgets. Here we identify them by alias path. Other methods like SourceClassName are also possible
             //in some cases we may have to specify mode conditions here to match a specific node

--- a/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
+++ b/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
@@ -7,15 +7,19 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
 {
     public override void Direct(ContentItemSource source, IContentItemActionProvider options)
     {
+        // Apply the conversions only to nodes under /About-Us (or your desired KX13 tree node)
+        // The system will evaluate all following conditions for each tree node which node AliasPath starts with /About-Us
+        // This includes the /About-Us node itself and all its child nodes (/About-Us/Our-philosophy, /About-Us/References, etc.)
         if (source.SourceNode!.NodeAliasPath.StartsWith("/About-Us"))
         {
-            // 1. Widget host page tree node: Ensure the template exists and is available in XbyK target project
+            // Identify the KX13 tree node that will host the widget in XbyK
             if (source.SourceNode.NodeAliasPath == "/About-Us")
             {
+                // Ensure this template exists in the XbyK target instance
                 options.OverridePageTemplate("DancingGoat.LandingPageSingleColumn");
             }
-            // 2. Nodes to be converted to widgets. Here we identify them by alias path. Other methods like SourceClassName are also possible
-            //in some cases we may have to specify mode conditions here to match a specific node
+            // Nodes to be converted to widgets. We will identify them by SourceClassName
+            // In some cases we may have to specify more conditions here to match a specific node
             else if (source.SourceClassName == "DancingGoatCore.AboutUsSection")
             {
                 // The widget identifier must match the one defined in the XbyK target project
@@ -24,9 +28,9 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
                     // Determine where to embed the widget
                     options.Location
                         .OnAncestorPage(-1)
-                        // the area has to match what's defined in the XbyK project template's view
+                        // The area has to match what's defined in the XbyK project template's view
                         .InEditableArea("top")
-                        // the section name has to match what's defined in the XbyK project
+                        // The section name has to match what's defined in the XbyK project
                         .InSection("DancingGoat.SingleColumnSection")
                         .InFirstZone();
 
@@ -34,14 +38,14 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
                     options.Properties.Fill(true, (itemProps, reusableItemGuid, childGuids) =>
                     {
                         // Simple way to achieve basic conversion of all properties
-                        // Skipping this because this is already shown in the samples.
-                        // we want to link the object as reusable content item instead - there's no need to duplicate the values in properties
                         // var widgetProps = JObject.FromObject(itemProps);
+                        // Skipping this step because this is already shown in the samples.
+                        // We want to link the object as reusable content item instead - there's no need to duplicate the values in properties
 
                         var widgetProps = new JObject();
 
-                        // Linked the converted page as a reusable content item into a single property of the widget.
-                        // Be sure to list the page class name appsettings in ConvertClassesToContentHub to make it reusable 
+                        // Convert the page to a reusable item using ConvertClassesToContentHub in appsettings.json
+                        // Then use a single widget property to link the converted page
                         widgetProps["aboutUsSectionItem"] = LinkedItemPropertyValue(reusableItemGuid!.Value);
                         widgetProps["alignment"] = "ImageLeft"; // Example of setting a specific property value
 
@@ -57,7 +61,7 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
         }
         else
         {
-            // don't do anything if the node is not under /About-Us node
+            // Add any handling you want to apply to pages that are not under the /About-us node
         }
     }
 }

--- a/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
+++ b/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
@@ -1,0 +1,63 @@
+using Migration.Tool.Source.Mappers.ContentItemMapperDirectives;
+using Newtonsoft.Json.Linq;
+
+namespace Migration.Tool.Extensions.CommunityMigrations;
+
+public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
+{
+    public override void Direct(ContentItemSource source, IContentItemActionProvider options)
+    {
+        if (source.SourceNode!.NodeAliasPath.StartsWith("/About-Us"))
+        {
+            // 1. Widget host page tree node: Ensure the template exists and is available in XbyK target project
+            if (source.SourceNode.NodeAliasPath == "/About-Us")
+            {
+                options.OverridePageTemplate("PageWithWidgetsDefaultTemplate");
+            }
+            // 2. Nodes to be converted to widgets. Here we identify them by alias path. Other methods like SourceClassName are also possible
+            //in some cases we may have to specify mode conditions here to match a specific node
+            else if (source.SourceClassName == "DancingGoatCore.AboutUsSection")
+            {
+                // The widget identifier must match the one defined in the XbyK target project
+                options.AsWidget("DancingGoat.Widgets.AboutUsSection", null, null, options =>
+                {
+                    // Determine where to embed the widget
+                    options.Location
+                        .OnAncestorPage(-1)
+                        // the area has to match what's defined in the XbyK project's view
+                        .InEditableArea("main-area")
+                        // the section name has to match what's defined in the XbyK project
+                        .InSection("DancingGoat.SingleColumnSection")
+                        .InFirstZone();
+
+                    // Construct the widget's properties
+                    options.Properties.Fill(true, (itemProps, reusableItemGuid, childGuids) =>
+                    {
+                        // Simple way to achieve basic conversion of all properties
+                        // Skipping this because this is already shown in the samples.
+                        // we want to link the object as reusable content item instead - there's no need to duplicate the values in properties
+                        // var widgetProps = JObject.FromObject(itemProps);
+
+                        var widgetProps = new JObject();
+
+                        // Linked the converted page as a reusable content item into a single property of the widget.
+                        // Be sure to list the page class name appsettings in ConvertClassesToContentHub to make it reusable 
+                        widgetProps["aboutUsSectionItem"] = LinkedItemPropertyValue(reusableItemGuid!.Value);
+                        widgetProps["alignment"] = "ImageLeft"; // Example of setting a specific property value
+
+                        return widgetProps;
+                    });
+                });
+            }
+            else
+            {
+                // Discard all other child nodes or handle them differently - based on your client's needs
+                options.Drop();
+            }
+        }
+        else
+        {
+            // don't do anything if the node is not under /About-Us node
+        }
+    }
+}

--- a/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
+++ b/Migration.Tool.Extensions/CommunityMigrations/AboutUsSectionsToWidgetsDirector.cs
@@ -24,8 +24,8 @@ public class AboutUsSectionsToWidgetsDirector : ContentItemDirectorBase
                     // Determine where to embed the widget
                     options.Location
                         .OnAncestorPage(-1)
-                        // the area has to match what's defined in the XbyK project's view
-                        .InEditableArea("main-area")
+                        // the area has to match what's defined in the XbyK project template's view
+                        .InEditableArea("top")
                         // the section name has to match what's defined in the XbyK project
                         .InSection("DancingGoat.SingleColumnSection")
                         .InFirstZone();

--- a/Migration.Tool.Extensions/CustomWidgetMigrations/HeroBanner/HeroBannerWidgetMigration.cs
+++ b/Migration.Tool.Extensions/CustomWidgetMigrations/HeroBanner/HeroBannerWidgetMigration.cs
@@ -24,7 +24,7 @@ public class HeroBannerWidgetMigration(ILogger<HeroBannerWidgetMigration> logger
 
             // this group of properties could be migrated to a separate reusable type (e.g., Link or CtaLink) and turned into one property with a reference - in the guide refer to the "Migrate widget data as reusable content" guide
             ["ctaText"] = singleVariant["properties"]!["ctaText"],
-            ["ctaOpenInNewTab"] = ctaTargetToBool(singleVariant["properties"]!["ctaTarget"]),
+            ["ctaOpenInNewTab"] = CtaTargetToBool(singleVariant["properties"]!["ctaTarget"]),
             // added property for better UX - to select between internal and external link in the target instance
             ["ctaTargetType"] = singleVariant["properties"]!["ctaUrlExternal"] != null && !string.IsNullOrEmpty(singleVariant["properties"]!["ctaUrlExternal"]!.ToString())
                 ? "absolute" : "page",
@@ -35,7 +35,7 @@ public class HeroBannerWidgetMigration(ILogger<HeroBannerWidgetMigration> logger
 
             // here we could utilize the reference to reusable Link or CtaLink again
             ["secondaryLinkText"] = singleVariant["properties"]!["cta2Text"],
-            ["secondaryLinkOpenInNewTab"] = ctaTargetToBool(singleVariant["properties"]!["cta2Target"]),
+            ["secondaryLinkOpenInNewTab"] = CtaTargetToBool(singleVariant["properties"]!["cta2Target"]),
             // added property for better UX - to select between internal and external link in the target instance
             ["secondaryLinkTargetType"] = singleVariant["properties"]!["ctaUrl2External"] != null && !string.IsNullOrEmpty(singleVariant["properties"]!["ctaUrl2External"]!.ToString())
                 ? "absolute" : "page",

--- a/Migration.Tool.Extensions/CustomWidgetMigrations/WidgetCustomSelectorMigration.cs
+++ b/Migration.Tool.Extensions/CustomWidgetMigrations/WidgetCustomSelectorMigration.cs
@@ -1,4 +1,3 @@
-using CMS.ContentEngine;
 using CMS.Core;
 using Microsoft.Extensions.Logging;
 using Migration.Tool.KXP.Api.Services.CmsClass;
@@ -19,87 +18,45 @@ public class WidgetCustomSelectorMigration(
 
     // version A - migrate the property to combined content selector with content item references
     // *******************************************************************************************
-    public Task<WidgetPropertyMigrationResult> MigrateWidgetProperty(
-        string key, JToken? value, WidgetPropertyMigrationContext context)
-    {
-        (int siteId, _) = context;
-
-        var refsToMedia = new List<object>();
-        if (value != null && !string.IsNullOrEmpty(value.ToString()))
-        {
-            // port the assets into the target solution before this migration runs
-            // map the value stored in widget property to th corresponding Asset GUID
-            var assetGuid = ...; // extract the asset GUID from the value, depending on how it is stored in the custom selector
-            // add the GUID as ContentItemReference to the result list
-            refsToMedia.Add(new ContentItemReference { Identifier = assetGuid });
-        }
-        var resultAsJToken = JToken.FromObject(refsToMedia);
-        return Task.FromResult(new WidgetPropertyMigrationResult(resultAsJToken));
-    }
-
-    // version B - migrate a property to text and use a custom component (e.g. ported Cloudinary selector) to display it in the target instance
-    // *******************************************************************************************
     // public Task<WidgetPropertyMigrationResult> MigrateWidgetProperty(
     //     string key, JToken? value, WidgetPropertyMigrationContext context)
     // {
     //     (int siteId, _) = context;
 
-    //     const string CUSTOM_PREFIX = "cloudinary_"; // prefix to identify the value as a custom selector value in the target instance
-
-    //     if (value != null)
+    //     var refsToMedia = new List<object>();
+    //     if (value != null && !string.IsNullOrEmpty(value.ToString()))
     //     {
-    //         var newValue = $"{CUSTOM_PREFIX}{value}"; // adapt the value to the format expected by the custom selector in the target instance
-    //         var resultAsJToken = JToken.FromObject(newValue);
-    //         return Task.FromResult(new WidgetPropertyMigrationResult(resultAsJToken));
+    //         // port the assets into the target solution before this migration runs
+    //         // map the value stored in widget property to th corresponding Asset GUID
+    //         var assetGuid = ...; // extract the asset GUID from the value, depending on how it is stored in the custom selector
+    //         // add the GUID as ContentItemReference to the result list
+    //         refsToMedia.Add(new ContentItemReference { Identifier = assetGuid });
     //     }
-    //     else
-    //     {
-    //         logger.LogError("Failed to parse '{ComponentName}' json {Json}", MigratedComponent, value?.ToString() ?? "<null>");
-
-    //         // leave value as it is
-    //         return Task.FromResult(new WidgetPropertyMigrationResult(value));
-    //     }
+    //     var resultAsJToken = JToken.FromObject(refsToMedia);
+    //     return Task.FromResult(new WidgetPropertyMigrationResult(resultAsJToken));
     // }
 
-    private async Task<ContentItemReference> CreateAssetContentItemFromCloudinary(JToken value)
+    // version B - migrate a property to text and use a custom component (e.g. ported Cloudinary selector) to display it in the target instance
+    // *******************************************************************************************
+    public Task<WidgetPropertyMigrationResult> MigrateWidgetProperty(
+        string key, JToken? value, WidgetPropertyMigrationContext context)
     {
-        const string KENTICO_DEFAULT_WORKSPACE_NAME = "KenticoDefault"; // value retrieved from the database
-        const int GLOBAL_ADMINISTRATOR_USER_ID = 53; // 53 is an ID of the Global Administrator user
-        const string ENGLISH_US_LANGUAGE = "en-US";
+        (int siteId, _) = context;
 
-        // Use the value to retrieve the asset and it's metadata from Cloudinary
+        const string CUSTOM_PREFIX = "cloudinary_"; // prefix to identify the value as a custom selector value in the target instance
 
-        // Prepare the Legacy media file properties from the data retrieved from Cloudinary
-        var legacyMediaFileAsset = new ContentItemAsset();
-        var legacyMediaFileTitle = value["buttonTarget"];
-        var legacyMediaFileDescription = value["buttonText"];
-
-        var ciManager = Service.Resolve<IContentItemManagerFactory>().Create(GLOBAL_ADMINISTRATOR_USER_ID);
-
-        var createContentItemParameters = new CreateContentItemParameters(
-            contentTypeName: "Legacy.MediaFile",
-            name: $"MigratedAsset{Guid.NewGuid():N}",
-            displayName: $"Asset - {legacyMediaFileTitle?.ToString() ?? "<null>"}",
-            languageName: ENGLISH_US_LANGUAGE,
-            workspaceName: KENTICO_DEFAULT_WORKSPACE_NAME
-        );
-
-        // the property names have to match the manually created content type's field names in the administration 
-        var contentItemData = new ContentItemData();
-        contentItemData.SetValue("HeroHeading", heroHeading?.ToString() ?? string.Empty);
-        contentItemData.SetValue("HeroTarget", heroTarget?.ToString() ?? string.Empty);
-        contentItemData.SetValue("HeroCallToAction", heroCallToAction?.ToString() ?? string.Empty);
-
-        int itemId = await ciManager.Create(createContentItemParameters, contentItemData);
-
-        if (itemId <= 0)
+        if (value != null)
         {
-            throw new Exception("Unable to create content item");
+            var newValue = $"{CUSTOM_PREFIX}{value}"; // adapt the value to the format expected by the custom selector in the target instance
+            var resultAsJToken = JToken.FromObject(newValue);
+            return Task.FromResult(new WidgetPropertyMigrationResult(resultAsJToken));
         }
-        if (!await ciManager.TryPublish(itemId, ENGLISH_US_LANGUAGE))
+        else
         {
-            throw new Exception("Could not publish Hero item");
+            logger.LogError("Failed to parse '{ComponentName}' json {Json}", MigratedComponent, value?.ToString() ?? "<null>");
+
+            // leave value as it is
+            return Task.FromResult(new WidgetPropertyMigrationResult(value));
         }
-        return new ContentItemReference { Identifier = CMS.ContentEngine.Internal.ContentItemInfo.Provider.Get(itemId).ContentItemGUID };
     }
 }

--- a/Migration.Tool.Extensions/ServiceCollectionExtensions.cs
+++ b/Migration.Tool.Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Migration.Tool.Extensions.CommunityMigrations;
 using Migration.Tool.Extensions.CustomWidgetMigrations;
 using Migration.Tool.Extensions.DefaultMigrations;
 using Migration.Tool.KXP.Api.Services.CmsClass;
+using Migration.Tool.Source.Mappers.ContentItemMapperDirectives;
 
 namespace Migration.Tool.Extensions;
 
@@ -30,6 +31,8 @@ public static class ServiceCollectionExtensions
         // services.AddReusableSchemaAutoGenerationSample();
         // services.AddTransient<ContentItemDirectorBase, SamplePageToWidgetDirector>();
         // services.AddTransient<ContentItemDirectorBase, SampleChildLinkDirector>();
+
+        services.AddTransient<ContentItemDirectorBase, AboutUsSectionsToWidgetsDirector>();
         return services;
     }
 }


### PR DESCRIPTION
## Motivation

Add a custom director class that transforms child pages of Dancing Goat's About Us page into widgets on the About us page.
The code is intended to be used in a training guide.

## How to test

1. Make sure the `AboutUsSectionsToWidgetsDirector` class is registered in the `ServiceCollectionExtensions`.
2. Ensure DancingGoatCore.AboutUsSection is included in appsettings.json configuration in "ConvertClassesToContentHub"
`"ConvertClassesToContentHub": "DancingGoatCore.AboutUsSection"`
3. Run the migration
